### PR TITLE
rails g`コマンドの際にいらないファイルが生成されないようにした

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>FlowSample</title>
+  <title>FlowSample#issues1</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,11 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+config.generators do |g|
+  g.assets false
+  g.helper false
+end
+
 module FlowSample
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
rails g`コマンドの際にいらないファイルが生成されないようにした